### PR TITLE
Handle corner case when likelihood is zero.

### DIFF
--- a/xlogit/mixed_logit.py
+++ b/xlogit/mixed_logit.py
@@ -521,6 +521,7 @@ class MixedLogit(ChoiceModel):
             proba.append(dev.to_cpu(proba_))
 
         lik = np.stack(proba).sum(axis=0)/R  # (N, )
+        lik = lik + 1e-200
         loglik = np.log(lik) if weights is None else np.log(lik)*weights
         loglik = loglik.sum()
         output = (-loglik, )


### PR DESCRIPTION
Add a small number 1e-200 to likelihood values to prevent applying log function on zeros.